### PR TITLE
SoLPotato unreachable thresholds fix & rework

### DIFF
--- a/defaultconfigs/solpotato-server.toml
+++ b/defaultconfigs/solpotato-server.toml
@@ -4,7 +4,7 @@
 	# they will get the benefits associated with that threshold.
 	#
 	#
-	thresholds = [3.0, 5.0, 7.0, 10.0, 13.0, 18.0, 25.0, 31.0]
+	thresholds = [1.5, 2.5, 3.5, 5.0, 6.5, 9.0, 11.5, 13.0, 16.0, 20.0]
 	# 
 	# Define custom benefits here. Each entry in the list corresponds to a benefit that will be obtained
 	# at the corresponding diversity threshold defined the list above. For example, the first entry in
@@ -26,7 +26,7 @@
 	# and Strength II at the corresponding threshold.
 	#
 	#
-	benefitsUnparsed = ["attribute,generic.max_health,2", "attribute,generic.max_health,2;effect,strength,0", "attribute,generic.max_health,2;effect,regeneration,0", "attribute,generic.max_health,2;effect,speed,0", "attribute,generic.max_health,2;attribute,generic.armor_toughness,2", "attribute,generic.armor_toughness,2;effect,strength,1", "attribute,generic.max_health,4", "attribute,generic.max_health,6"]
+	benefitsUnparsed = ["attribute,generic.max_health,2", "attribute,generic.max_health,2;effect,strength,0", "attribute,generic.max_health,2;effect,regeneration,0", "attribute,generic.max_health,2;effect,speed,0", "attribute,generic.max_health,2;attribute,generic.armor_toughness,2", "attribute,generic.armor_toughness,2;effect,strength,1", "attribute,generic.max_health,4", "attribute,generic.max_health,6", "effect,resistance,0", "effect,resistance,1"]
 	# The minimum number of foods a player needs to eat before any benefits are applied.
 	#
 	#
@@ -37,7 +37,7 @@
 	# Foods in this list won't contribute to food diversity.
 	#
 	#
-	blacklist = []
+	blacklist = ["minecraft:air"]
 	#
 	# When this list contains anything, the blacklist is ignored and instead only foods from here count.
 	#
@@ -63,7 +63,7 @@
 	#
 	#
 	#Range: 1 ~ 1000
-	queueSize = 32
+	queueSize = 16
 
 [Advanced]
 	# These config options all affect the technical details of how diversity is calculated.
@@ -89,19 +89,19 @@
 	#
 	#
 	#Range: 0 ~ 1000
-	endDecay = 32
+	endDecay = 16
 	#
 	# How many meals in the past should the diversity time penalty start to apply.
 	# **Needs to be less than queueSize and less than or equal to endDecay!!!**
 	#
 	#
 	#Range: 0 ~ 1000
-	startDecay = 0
+	startDecay = 6
 	#
 	# Whether blacklisted foods should still take a spot in the queue, even if they don't contribute any diversity.
 	#
 	#
-	shouldForbiddenCount = true
+	shouldForbiddenCount = false
 
 [Complexity]
 	# Define custom complexity values for individual foods here.
@@ -111,5 +111,5 @@
 	# Note that tags are NOT currently supported.
 	#
 	#
-	complexityUnparsed = ["minecraft:golden_carrot,2", "minecraft:golden_carrot,2", "minecraft:enchanted_golden_apple,5"]
+	complexityUnparsed = ["minecraft:golden_carrot,2", "minecraft:golden_apple,3", "minecraft:enchanted_golden_apple,8"]
 


### PR DESCRIPTION
SoL Potato has buffs at a score diversity of 25 and 31 that are unreachable with the config in the game (and the only way to reach the one at 18 would be to eat 30 different food items and then end it with a golden carrot and an enchanted golden apple, and you would have to keep rotating in 30 unique food and uncraftable enchanted apples)

This config brings a few changes and bugfixes that make it work as the following : 

**Bugfix** - `minecraft:air` is blacklisted and `shouldForbiddenCount` is set to `false` so that when saturation or other bugs buffs "feed you" air, even if it happens multiple times, your food history (and therefore your diversity score) doesn't get messed up **Bugfix & Change** - the `complexityUnparsed` list contained `minecraft:golden_carrot` twice instead of (most likely) containing the golden apple that's not enchanted. Complexity values are now representative of the rarity of those.

**Thresholds and Queue Size rework** :
`queueSize` and `endDecay` are now 16 to account for the 14 food items from a fully upgraded (golden) lunchbox + 2 extra `startDecay` is now 6 which means that the multiplier of the last 6 food items you ate stays at 1 (in order to keep the buffs from maxing your food diversity for longer)


The food diversity thresholds have been lowered to account for the smaller queue so that they are all reachable, the related bonuses are now set to : 1.5 - +2 Max Health
2.5 - +2 Max Health, Strength 1
3.5 - +2 Max Health, Regeneration 1
5.0 - +2 Max Health, Speed 1
6.5 - +2 Max Health, +2 Armor Toughness
9.0 - +2 Armor Toughness, Strength 2
11.5 - +4 Max Health
13.0 - +6 Max Health
16.0 - Resistance 1
20.0 - Resistance 2


Here are some example scores players could get : 

- Eating the same food would give a score of 1 just like with the previous config, which unlocks nothing
- Alternating up to 6 food items would give a score of up to 6 (1 to 1)
- Having a full lunchbox with 14 unique food items would give them a score of 11.2, unlocking everything that was reachable in the default config
- Having a full lunchbox with 14 unique food items and eating 2 extra unique food items from time to time lets you get a score of 11.5, unlocking the first unreachable buff of +4HP
- Having a full lunchbox with 14 unique food items + golden apples in the rotation would let you get a score of 13.4 until you eat 6 more food items (then it starts loosing 0.3 for every food you eat until it reaches the 16th position and it's score becomes 0)
- Having a full lunchbox with 14 unique food items + enchanted golden apples in the rotation would let you get a score of 18.4
- Having a full lunchbox with 14 unique food items + enchanted golden apples + golden apples and golden carrots would get you a score of 21.5