### PR TITLE
Add plague clouds to the champions blacklist

### DIFF
--- a/defaultconfigs/champions-entities.toml
+++ b/defaultconfigs/champions-entities.toml
@@ -70,3 +70,10 @@
 	presetAffixes = []
 	affixList = []
 	affixPermission = "BLACKLIST"
+[[entities]]
+	entity = "rats:plague_cloud"
+	minTier = 0
+	maxTier = 0
+	presetAffixes = []
+	affixList = []
+	affixPermission = "BLACKLIST"


### PR DESCRIPTION
Plague clouds are spawned by the black death when you start fighting it and can fly, give you the plague and already hit hard without being a champion, if they are a champion they can make the boss impossible to kill. The other summons (rats and big rats) are more manageable even if they spawn as champions since they keep to the ground but a champion cloud would basically force a reset