### PR TITLE
Login/spawn protection time increase

### DIFF
--- a/config/logprot-common.toml
+++ b/config/logprot-common.toml
@@ -2,7 +2,7 @@
 [Login-settings]
 	#Time in ticks the logging player is invulnerable, 20 ticks = 1sec. Default is 50secs = 1000 ticks
 	#Range: 0 ~ 50000
-	invulnerabilityTime = 100
+	invulnerabilityTime = 12000
 	#Max distance in blocks(2d) the invulnerability lasts, default: 10
 	#Range: 1 ~ 200
 	maxDistance = 4


### PR DESCRIPTION
Since the modpack has now released and support for multiplayer is starting to get into consideration. I think raising login protection to 5 minutes is a must. The current default value of 5 seconds does not even cover the early phases of loading into a server.

The loading time until I can move in game has been consistently between 2 and 3 minutes for me with a server on the same PC (so perfect connection) and a mid range CPU (i5 8300H).  Lower specs could most certainly take 5 to 10 minutes which is why I think a default value of 10 minutes should be sensible. 

The invulnerability does not persist as soon as a player moves which removes any opportunity for exploiting it.