### PR TITLE
Add End Slimes to the champions blacklist

### DIFF
--- a/defaultconfigs/champions-entities.toml
+++ b/defaultconfigs/champions-entities.toml
@@ -77,3 +77,10 @@
 	presetAffixes = []
 	affixList = []
 	affixPermission = "BLACKLIST"
+[[entities]]
+	entity = "betterend:end_slime"
+	minTier = 0
+	maxTier = 0
+	presetAffixes = []
+	affixList = []
+	affixPermission = "BLACKLIST"


### PR DESCRIPTION
End slimes allow for some (way too) crazy enchant book drops, I have been able to fill a backpack with enchants from a single big slime, as it splits into about 5 smaller slimes which each split into 5 or more tiny slimes. 

Thanks to the difficulty evolution, usually at least half of them spawn as skilled or higher when a player gets to the end. 

Given how they deal no damage even while wearing a forgotten hat for extra luck, it's even possible to maximize looting to get jewelry as well as double enchant books, which is simply broken (I assume this is the reason why slimes and magma cubes are also blacklisted)