### PR TITLE
Propsed changes for strorage

### DIFF
--- a/defaultconfigs/refinedstorage-server.toml
+++ b/defaultconfigs/refinedstorage-server.toml
@@ -1,0 +1,275 @@
+
+[upgrades]
+	#The additional energy used by the Fortune 3 Upgrade
+	#Range: > 0
+	fortune3UpgradeUsage = 0
+	#The additional energy used by the Speed Upgrade
+	#Range: > 0
+	speedUpgradeUsage = 0
+	#The additional energy used by the Crafting Upgrade
+	#Range: > 0
+	craftingUpgradeUsage = 0
+	#The additional energy used by the Fortune 1 Upgrade
+	#Range: > 0
+	fortune1UpgradeUsage = 0
+	#The additional energy used by the Fortune 2 Upgrade
+	#Range: > 0
+	fortune2UpgradeUsage = 0
+	#The additional energy used by the Regulator Upgrade
+	#Range: > 0
+	regulatorUpgradeUsage = 0
+	#The additional energy used by the Stack Upgrade
+	#Range: > 0
+	stackUpgradeUsage = 0
+	#The additional energy used by the Silk Touch Upgrade
+	#Range: > 0
+	silkTouchUpgradeUsage = 0
+	#The additional energy used by the Range Upgrade
+	#Range: > 0
+	rangeUpgradeUsage = 0
+
+[controller]
+	#Whether the Controller uses energy
+	useEnergy = false
+	#The maximum energy that the Controller can receive
+	#Range: > 0
+	maxTransfer = 2147483647
+	#The base energy used by the Controller
+	#Range: > 0
+	baseUsage = 0
+	#The energy capacity of the Controller
+	#Range: > 0
+	capacity = 1
+
+[cable]
+	#The energy used by the Cable
+	#Range: > 0
+	usage = 0
+
+[grid]
+	#The energy used by Crafting Grids
+	#Range: > 0
+	craftingGridUsage = 0
+	#The energy used by Fluid Grids
+	#Range: > 0
+	fluidGridUsage = 0
+	#The energy used by Pattern Grids
+	#Range: > 0
+	patternGridUsage = 0
+	#The energy used by Grids
+	#Range: > 0
+	gridUsage = 0
+
+[diskDrive]
+	#The energy used by the Disk Drive
+	#Range: > 0
+	usage = 0
+	#The energy used per disk in the Disk Drive
+	#Range: > 0
+	diskUsage = 0
+
+[storageBlock]
+	#The energy used by the 4k Storage Block
+	#Range: > 0
+	fourKUsage = 0
+	#The energy used by the 16k Storage Block
+	#Range: > 0
+	sixteenKUsage = 0
+	#The energy used by the 64k Storage Block
+	#Range: > 0
+	sixtyFourKUsage = 0
+	#The energy used by the 1k Storage Block
+	#Range: > 0
+	oneKUsage = 0
+	#The energy used by the Creative Storage Block
+	#Range: > 0
+	creativeUsage = 0
+
+[fluidStorageBlock]
+	#The energy used by the 1024k Fluid Storage Block
+	#Range: > 0
+	thousandTwentyFourKUsage = 0
+	#The energy used by the 4096k Fluid Storage Block
+	#Range: > 0
+	fourThousandNinetySixKUsage = 0
+	#The energy used by the 64k Fluid Storage Block
+	#Range: > 0
+	sixtyFourKUsage = 0
+	#The energy used by the Creative Fluid Storage Block
+	#Range: > 0
+	creativeUsage = 0
+	#The energy used by the 256k Fluid Storage Block
+	#Range: > 0
+	twoHundredFiftySixKUsage = 0
+
+[externalStorage]
+	#The energy used by the External Storage
+	#Range: > 0
+	usage = 0
+
+[importer]
+	#The energy used by the Importer
+	#Range: > 0
+	usage = 0
+
+[exporter]
+	#The energy used by the Exporter
+	#Range: > 0
+	usage = 0
+
+[networkReceiver]
+	#The energy used by the Network Receiver
+	#Range: > 0
+	usage = 0
+
+[networkTransmitter]
+	#The energy used by the Network Transmitter
+	#Range: > 0
+	usage = 0
+
+[relay]
+	#The energy used by the Relay
+	#Range: > 0
+	usage = 0
+
+[detector]
+	#The energy used by the Detector
+	#Range: > 0
+	usage = 0
+
+[securityManager]
+	#The energy used by the Security Manager
+	#Range: > 0
+	usage = 0
+	#The additional energy used by Security Cards in the Security Manager
+	#Range: > 0
+	usagePerCard = 0
+
+[interface]
+	#The energy used by the Interface
+	#Range: > 0
+	usage = 0
+
+[fluidInterface]
+	#The energy used by the Fluid Interface
+	#Range: > 0
+	usage = 0
+
+[wirelessTransmitter]
+	#The additional range per Range Upgrade in the Wireless Transmitter
+	#Range: > 0
+	rangePerUpgrade = 16
+	#The energy used by the Wireless Transmitter
+	#Range: > 0
+	usage = 0
+	#The base range of the Wireless Transmitter
+	#Range: > 0
+	baseRange = 16
+
+[storageMonitor]
+	#The energy used by the Storage Monitor
+	#Range: > 0
+	usage = 0
+
+[wirelessGrid]
+	#Whether the Wireless Grid uses energy
+	useEnergy = false
+	#The energy used by the Wireless Grid to insert items
+	#Range: > 0
+	insertUsage = 0
+	#The energy used by the Wireless Grid to open
+	#Range: > 0
+	openUsage = 0
+	#The energy used by the Wireless Grid to extract items
+	#Range: > 0
+	extractUsage = 0
+	#The energy capacity of the Wireless Grid
+	#Range: > 0
+	capacity = 1
+
+[wirelessFluidGrid]
+	#Whether the Wireless Fluid Grid uses energy
+	useEnergy = false
+	#The energy used by the Wireless Fluid Grid to insert fluids
+	#Range: > 0
+	insertUsage = 0
+	#The energy used by the Wireless Fluid Grid to open
+	#Range: > 0
+	openUsage = 0
+	#The energy used by the Wireless Fluid Grid to extract fluids
+	#Range: > 0
+	extractUsage = 0
+	#The energy capacity of the Wireless Fluid Grid
+	#Range: > 0
+	capacity = 1
+
+[constructor]
+	#The energy used by the Constructor
+	#Range: > 0
+	usage = 0
+
+[destructor]
+	#The energy used by the Destructor
+	#Range: > 0
+	usage = 0
+
+[diskManipulator]
+	#The energy used by the Disk Manipulator
+	#Range: > 0
+	usage = 0
+
+[portableGrid]
+	#Whether the Portable Grid uses energy
+	useEnergy = false
+	#The energy used by the Portable Grid to insert items or fluids
+	#Range: > 0
+	insertUsage = 0
+	#The energy used by the Portable Grid to open
+	#Range: > 0
+	openUsage = 0
+	#The energy used by the Portable Grid to extract items or fluids
+	#Range: > 0
+	extractUsage = 0
+	#The energy capacity of the Portable Grid
+	#Range: > 0
+	capacity = 0
+
+[crafter]
+	#The energy used by the Crafter
+	#Range: > 0
+	usage = 0
+	#The energy used for every Pattern in the Crafter
+	#Range: > 0
+	patternUsage = 0
+
+[crafterManager]
+	#The energy used by the Crafter Manager
+	#Range: > 0
+	usage = 0
+
+[craftingMonitor]
+	#The energy used by the Crafting Monitor
+	#Range: > 0
+	usage = 0
+
+[wirelessCraftingMonitor]
+	#Whether the Wireless Crafting Monitor uses energy
+	useEnergy = false
+	#The energy used by the Wireless Crafting Monitor to cancel a crafting task
+	#Range: > 0
+	cancelUsage = 0
+	#The energy used by the Wireless Crafting Monitor to open
+	#Range: > 0
+	openUsage = 0
+	#The energy capacity of the Wireless Crafting Monitor
+	#Range: > 0
+	capacity = 1
+	#The energy used by the Wireless Crafting Monitor to cancel all crafting tasks
+	#Range: > 0
+	cancelAllUsage = 0
+
+[autocrafting]
+	#The autocrafting calculation timeout in milliseconds, crafting tasks taking longer than this to calculate are cancelled to avoid server strain
+	#Range: > 5000
+	calculationTimeoutMs = 5000
+

--- a/kubejs/client_scripts/refined_client.js
+++ b/kubejs/client_scripts/refined_client.js
@@ -1,0 +1,31 @@
+// priority: 0
+
+console.info('Hello, World! (You will see this line every time client resources reload)')
+
+onEvent('jei.hide.items', event => {
+	event.hide('#refinedstorage:network_transmitter')
+	event.hide('#refinedstorage:network_receiver')
+	event.hide('#refinedstorage:relay')
+	event.hide('#refinedstorage:detector')
+	event.hide('#refinedstorage:crafter')
+	event.hide('#refinedstorage:crafter_manager')
+	event.hide('#refinedstorage:crafting_monitor')
+	event.hide('refinedstorage:pattern')
+	event.hide('refinedstorage:portable_grid')
+	event.hide('refinedstorage:creative_portable_grid')
+	event.hide('refinedstorage:crafting_upgrade')
+	event.hide('refinedstorage:fortune_3_upgrade')
+	event.hide('refinedstorage:fortune_2_upgrade')
+	event.hide('refinedstorage:fortune_1_upgrade')
+	event.hide('refinedstorage:silk_touch_upgrade')
+	event.hide('refinedstorage:constructor')
+	event.hide('refinedstorage:destructor')
+	event.hide('refinedstorage:wireless_crafting_monitor')
+	event.hide('refinedstorage:creative_wireless_crafting_monitor')
+	event.hide('#refinedstorage:pattern_grid')
+})
+
+onEvent('item.tooltip', tooltip => {
+	tooltip.add('#refinedstorage:controller', 'Dumbed-down with no power requirment and autocrafting removed.')
+	tooltip.add('refinedstorage:1k_storage_part', 'Rumored to be found hidden in old ruins of ancient civilizations.')
+})

--- a/kubejs/server_scripts/refined_server.js
+++ b/kubejs/server_scripts/refined_server.js
@@ -1,0 +1,118 @@
+// priority: 0
+
+settings.logAddedRecipes = true
+settings.logRemovedRecipes = true
+settings.logSkippedRecipes = false
+settings.logErroringRecipes = true
+
+console.info('Hello, World! (You will see this line every time server resources reload)')
+
+onEvent('recipes', event => {
+	//remove varius refined storage blocks from crafting
+	event.remove({output: '#refinedstorage:network_transmitter'})
+	event.remove({output: '#refinedstorage:network_receiver'})
+	event.remove({output: '#refinedstorage:relay'})
+	event.remove({output: '#refinedstorage:detector'})
+	event.remove({output: '#refinedstorage:crafter'})
+	event.remove({output: '#refinedstorage:crafter_manager'})
+	event.remove({output: '#refinedstorage:crafting_monitor'})
+	event.remove({output: 'refinedstorage:pattern'})
+	event.remove({output: 'refinedstorage:portable_grid'})
+	event.remove({output: 'refinedstorage:crafting_upgrade'})
+	event.remove({output: 'refinedstorage:fortune_3_upgrade'})
+	event.remove({output: 'refinedstorage:fortune_2_upgrade'})
+	event.remove({output: 'refinedstorage:fortune_1_upgrade'})
+	event.remove({output: 'refinedstorage:silk_touch_upgrade'})
+	event.remove({output: 'refinedstorage:constructor'})
+	event.remove({output: 'refinedstorage:destructor'})
+	event.remove({output: 'refinedstorage:wireless_crafting_monitor'})
+	event.remove({output: '#refinedstorage:pattern_grid'})
+	event.remove({output: 'refinedstorage:1k_storage_part'})
+	event.remove({output: 'refinedstorage:64k_fluid_storage_part'})
+	//recipies to turn normal disk into fluid disk
+	event.shaped('refinedstorage:64k_fluid_storage_part', [
+		'SBS',
+		'BDB',
+		'SBS'
+	], {
+		S: '#forge:silicon',
+		B: 'minecraft:bucket',
+		D: 'refinedstorage:1k_storage_part'
+	})
+	event.shaped('refinedstorage:256k_fluid_storage_part', [
+		'SBS',
+		'BDB',
+		'SBS'
+	], {
+		S: '#forge:silicon',
+		B: 'minecraft:bucket',
+		D: 'refinedstorage:4k_storage_part'
+	})
+	event.shaped('refinedstorage:1024k_fluid_storage_part', [
+		'SBS',
+		'BDB',
+		'SBS'
+	], {
+		S: '#forge:silicon',
+		B: 'minecraft:bucket',
+		D: 'refinedstorage:16k_storage_part'
+	})
+	event.shaped('refinedstorage:4096k_fluid_storage_part', [
+		'SBS',
+		'BDB',
+		'SBS'
+	], {
+		S: '#forge:silicon',
+		B: 'minecraft:bucket',
+		D: 'refinedstorage:64k_storage_part'
+	})
+})
+
+onEvent('item.tags', event => {
+
+})
+
+onEvent("lootjs", (event) => {
+	//event.enableLogging();
+	//console.info('loot inject')
+	event
+		.addLootTableModifier("minecraft:chests/simple_dungeon", "minecraft:chests/buried_treasure", "minecraft:chests/abandoned_mineshaft", "minecraft:chests/desert_pyramid", "minecraft:chests/igloo_chest", "minecraft:chests/jungle_temple", "minecraft:chests/nether_bridge", "minecraft:chests/shipwreck_treasure", "minecraft:chests/stronghold_corridor", "minecraft:chests/stronghold_crossing", "minecraft:chests/underwater_ruin_big", "minecraft:chests/underwater_ruin_small")
+		.randomChance(0.175)
+		.thenAdd('refinedstorage:1k_storage_part')
+		.randomChance(0.33)
+		.thenRemove('refinedstorage:1k_storage_part')
+		.thenAdd('refinedstorage:4k_storage_part')
+		.randomChance(0.33)
+		.thenRemove('refinedstorage:4k_storage_part')
+		.thenAdd('refinedstorage:16k_storage_part')
+		.randomChance(0.33)
+		.thenRemove('refinedstorage:16k_storage_part')
+		.thenAdd('refinedstorage:64k_storage_part');
+	event
+		.addLootTableModifier("minecraft:chests/end_city_treasure")
+		.randomChance(0.75)
+		.thenAdd('refinedstorage:1k_storage_part')
+		.randomChance(0.45)
+		.thenRemove('refinedstorage:1k_storage_part')
+		.thenAdd('refinedstorage:4k_storage_part')
+		.randomChance(0.45)
+		.thenRemove('refinedstorage:4k_storage_part')
+		.thenAdd('refinedstorage:16k_storage_part')
+		.randomChance(0.45)
+		.thenRemove('refinedstorage:16k_storage_part')
+		.thenAdd('refinedstorage:64k_storage_part');
+	event
+		.addLootTableModifier("minecraft:gameplay/fishing/treasure")
+		.randomChance(0.05)
+		.thenRemove(Ingredient.getAll())
+		.thenAdd('refinedstorage:1k_storage_part')
+		.randomChance(0.33)
+		.thenRemove('refinedstorage:1k_storage_part')
+		.thenAdd('refinedstorage:4k_storage_part')
+		.randomChance(0.33)
+		.thenRemove('refinedstorage:4k_storage_part')
+		.thenAdd('refinedstorage:16k_storage_part')
+		.randomChance(0.33)
+		.thenRemove('refinedstorage:16k_storage_part')
+		.thenAdd('refinedstorage:64k_storage_part');
+});


### PR DESCRIPTION
Required mod additions:
https://www.curseforge.com/minecraft/mc-mods/refined-storage
https://www.curseforge.com/minecraft/mc-mods/lootjs

Add refined storage
Remove power requirement
Remove automation related parts of refined
Remove recipe for storage disk
Add Storage disk to the following loot tables at the rates of 

- 17.5% 1k
- 5.78% 4k
- 1.91% 16k
- 0.63% 64k

- "minecraft:chests/simple_dungeon"
- "minecraft:chests/buried_treasure"
- "minecraft:chests/abandoned_mineshaft"
- "minecraft:chests/desert_pyramid"
- "minecraft:chests/igloo_chest"
- "minecraft:chests/jungle_temple"
- "minecraft:chests/nether_bridge"
- "minecraft:chests/shipwreck_treasure"
- "minecraft:chests/stronghold_corridor"
- "minecraft:chests/stronghold_crossing"
- "minecraft:chests/underwater_ruin_big"
- "minecraft:chests/underwater_ruin_small"

rates of the following for "minecraft:chests/end_city_treasure"

- 75% 1k
- 33.75% 4k
- 15.19% 16k
- 6.83% 32k

rates of the following for "minecraft:gameplay/fishing/treasure"

- 5% 1k
- 1.65% 4k
- 0.54% 16k
- 0.18% 32k


More detailed list of items made unobtainable from the mod

- refinedstorage:network_transmitter
- refinedstorage:network_receiver
- refinedstorage:relay
- refinedstorage:detector
- refinedstorage:crafter
- refinedstorage:crafter_manager
- refinedstorage:crafting_monitor
- refinedstorage:pattern
- refinedstorage:portable_grid
- refinedstorage:crafting_upgrade
- refinedstorage:fortune_3_upgrade
- refinedstorage:fortune_2_upgrade
- refinedstorage:fortune_1_upgrade
- refinedstorage:silk_touch_upgrade
- refinedstorage:constructor
- refinedstorage:destructor
- refinedstorage:wireless_crafting_monitor
- refinedstorage:pattern_grid