### PR TITLE
Mushroom stem recipe for Feywild

### DIFF
--- a/scripts/craftingTable.zs
+++ b/scripts/craftingTable.zs
@@ -103,9 +103,6 @@ for allItems in game.items {
 
 craftingTable.removeByRegex("buddycards:.*_card_display");
 
-
-
-
-
-
-
+craftingTable.addShaped("mush_stem_feywild", <item:minecraft:mushroom_stem> * 4, 
+[[<item:enhanced_mushrooms:red_mushroom_stem>, <item:enhanced_mushrooms:red_mushroom_stem>],
+ [<item:enhanced_mushrooms:red_mushroom_stem>, <item:enhanced_mushrooms:red_mushroom_stem>]]);


### PR DESCRIPTION
Adds recipe to change `enhanced_mushrooms:red_mushroom_stem` into `minecraft:mushroom_stem` so that player can craft `feywild:summoning_scroll_shroomling`

Issue referenced in #232 

![image](https://user-images.githubusercontent.com/127772330/231476071-02b232c2-a9f5-4042-9488-66ef84b7ada1.png)
![image](https://user-images.githubusercontent.com/127772330/231476122-c3716082-1aab-4dbe-ae06-60398de77ac0.png)
