### PR TITLE
Fix tomes providing infinite magic xp

### DIFF
--- a/scripts/magicTome.zs
+++ b/scripts/magicTome.zs
@@ -42,7 +42,7 @@ CTEventManager.register<MCRightClickItemEvent>((event) => {
 	
 	var canUse = true;
 	
-	if (stack.hasTag && stack.tag.contains("formerReaders")) {
+	if (stack.hasTag && (stack.tag as MapData).contains("formerReaders")) {
 		var nbtTag = stack.tag as MapData;
 		var formerReaders = nbtTag.getAt("formerReaders");
 		for reader in formerReaders.asList() {


### PR DESCRIPTION
Yes, a cast is all that's needed here; IData.contains does not work for unknown reasons, but MapData.contains does.

I have tested this in a local world and on a server. It works as expected now; every tome is only usable once per player.