### PR TITLE
Atritribute fix config with some tweaks

### DIFF
--- a/config/attributefix-common.toml
+++ b/config/attributefix-common.toml
@@ -1,0 +1,144 @@
+
+#Values for the minecraft:generic.max_health attribute.
+[minecraft_generic_max_health]
+	#Whether or not this attribute should be modified.
+	enabled = true
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 1.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 2048
+
+#Values for the minecraft:generic.follow_range attribute.
+[minecraft_generic_follow_range]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+
+#Values for the minecraft:generic.knockback_resistance attribute.
+[minecraft_generic_knockback_resistance]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+
+#Values for the minecraft:generic.movement_speed attribute.
+[minecraft_generic_movement_speed]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+
+#Values for the minecraft:generic.flying_speed attribute.
+[minecraft_generic_flying_speed]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+
+#Values for the minecraft:generic.attack_damage attribute.
+[minecraft_generic_attack_damage]
+	#Whether or not this attribute should be modified.
+	enabled = true
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 6000
+
+#Values for the minecraft:generic.attack_knockback attribute.
+[minecraft_generic_attack_knockback]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+
+#Values for the minecraft:generic.attack_speed attribute.
+[minecraft_generic_attack_speed]
+	#Whether or not this attribute should be modified.
+	enabled = true
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 20
+
+#Values for the minecraft:generic.armor attribute.
+[minecraft_generic_armor]
+	#Whether or not this attribute should be modified.
+	enabled = true
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 60
+
+#Values for the minecraft:generic.armor_toughness attribute.
+[minecraft_generic_armor_toughness]
+	#Whether or not this attribute should be modified.
+	enabled = true
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 30
+
+#Values for the minecraft:generic.luck attribute.
+[minecraft_generic_luck]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = -1024.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+
+#Values for the minecraft:zombie.spawn_reinforcements attribute.
+[minecraft_zombie_spawn_reinforcements]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+
+#Values for the minecraft:horse.jump_strength attribute.
+[minecraft_horse_jump_strength]
+	#Whether or not this attribute should be modified.
+	enabled = false
+	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	min = 0.0
+	#The maximum value for the attribute.
+	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
+	max = 65536.0
+

--- a/config/attributefix-common.toml
+++ b/config/attributefix-common.toml
@@ -8,7 +8,7 @@
 	min = 1.0
 	#The maximum value for the attribute.
 	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
-	max = 2048
+	max = 4096
 
 #Values for the minecraft:generic.follow_range attribute.
 [minecraft_generic_follow_range]

--- a/config/attributefix-common.toml
+++ b/config/attributefix-common.toml
@@ -57,7 +57,7 @@
 #Values for the minecraft:generic.attack_damage attribute.
 [minecraft_generic_attack_damage]
 	#Whether or not this attribute should be modified.
-	enabled = true
+	enabled = false
 	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
 	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
 	min = 0.0

--- a/config/attributefix-common.toml
+++ b/config/attributefix-common.toml
@@ -24,7 +24,7 @@
 #Values for the minecraft:generic.knockback_resistance attribute.
 [minecraft_generic_knockback_resistance]
 	#Whether or not this attribute should be modified.
-	enabled = false
+	enabled = true
 	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
 	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
 	min = -65536.0

--- a/config/attributefix-common.toml
+++ b/config/attributefix-common.toml
@@ -27,7 +27,7 @@
 	enabled = false
 	#The minimum vallue for the attribute. Changing this may have unforseen consequences.
 	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
-	min = 0.0
+	min = -65536.0
 	#The maximum value for the attribute.
 	#Range: -1.7976931348623157E308 ~ 1.7976931348623157E308
 	max = 65536.0


### PR DESCRIPTION
Requires the following mod
https://www.curseforge.com/minecraft/mc-mods/attributefix


The following are the only enabled attribute changes and the values they are set to 
Max Health 4096 (4x the default) (now 4096 mainly for dragons stage 5s should be fun)
~~Generic Attack Damage 6000 (around 2x default if i recall correctly)~~
Generic Attack Speed 20 (i cant recall what the default for mc is just fairly sure its less then 20) 
Generic Armor 60 (2x the default)
Generic Armor Toughness 30 (1.5x the default)