### PR TITLE
Summoned vex champion fix

### DIFF
--- a/defaultconfigs/champions-entities.toml
+++ b/defaultconfigs/champions-entities.toml
@@ -98,3 +98,10 @@
 	presetAffixes = []
 	affixList = []
 	affixPermission = "BLACKLIST"
+[[entities]]
+	entity = "arsnouveau:ally_vex"
+	minTier = 0
+	maxTier = 0
+	presetAffixes = []
+	affixList = []
+	affixPermission = "BLACKLIST"

--- a/defaultconfigs/champions-entities.toml
+++ b/defaultconfigs/champions-entities.toml
@@ -99,7 +99,7 @@
 	affixList = []
 	affixPermission = "BLACKLIST"
 [[entities]]
-	entity = "arsnouveau:ally_vex"
+	entity = "ars_nouveau:ally_vex"
 	minTier = 0
 	maxTier = 0
 	presetAffixes = []


### PR DESCRIPTION
Prevents ars nouveau summoned vex from becoming champions and dropping coins/enchanted books as loot.