### PR TITLE
Removed improvedmobs magic resistance

### DIFF
--- a/config/improvedmobs/common.toml
+++ b/config/improvedmobs/common.toml
@@ -193,10 +193,10 @@
 	#Maximum increase in knockback
 	"Max Knockback" = 0.3
 	#Magic resistance will be increased by difficulty*0.0016*x. Set to 0 to disable
-	"Magic Resistance Increase" = 1.0
+	"Magic Resistance Increase" = 0.0
 	#Maximum increase in magic resistance. Magic reduction is percentage
 	#Range: 0.0 ~ 1.0
-	"Max Magic Resistance" = 0.8
+	"Max Magic Resistance" = 0.0
 	#Projectile Damage will be multiplied by 1+difficulty*0.008*x. Set to 0 to disable
 	"Projectile Damage Increase" = 1.0
 	#Projectile damage will be multiplied by maximum of this


### PR DESCRIPTION
This simply seems like a counterintuitive imaginary number, leads to weird results with hidden variables when calculating damage in world, and is an unnecessary nerf to a play-style that sorely needs more damage.

Pros:
- leads to more predictable magic damage numbers
- provides a large buff to specific ars nouveau spells

Cons:
- does not solve the issue of magical sword enchants being overused/op
- may in fact buff said enchants

Feel free to propose a more balanced solution if ya'll feel the need to.