### PR TITLE
Added ability to autocomplete patreon chapter

### DIFF
--- a/config/ftbquests/quests/chapters/the_patreon.snbt
+++ b/config/ftbquests/quests/chapters/the_patreon.snbt
@@ -58,6 +58,22 @@
 				type: "checkmark"
 				title: "THANK YOU FOR YOUR SUPPORT!"
 			}]
+			rewards: [{
+				id: "52692623AE499FAB"
+				type: "command"
+				title: "Complete Chapter"
+				icon: {
+					id: "paraglider:heart_container"
+					Count: 1b
+					ForgeCaps: {
+						"dungeons_libraries:built_in_enchantments": {
+							BuiltInEnchantments: [ ]
+						}
+					}
+				}
+				command: "/ftbquests change_progress @p complete 1E11739B02616720"
+				player_command: false
+			}]
 		}
 		{
 			title: "Rebecca"


### PR DESCRIPTION
Feel free to not accept if it's disrespectful, but seen a few complaints from questbook completionists about how tedious completing every quest in this chapter is. This commit adds a reward that completes the chapter through a command.